### PR TITLE
Attempt negative charge count fix

### DIFF
--- a/mod/scripts/vscripts/holoshift_recharge.gnut
+++ b/mod/scripts/vscripts/holoshift_recharge.gnut
@@ -33,6 +33,7 @@ bool IsLaunched = false
                         if(!player.IsPhaseShifted()){
                             if(player in playerDecoyActiveFrom){
                                 float chargeCount = float(player.GetOffhandWeapon(1).GetWeaponPrimaryClipCountMax()) - ((Time() - playerDecoyActiveFrom[player])*rechargeMultiplier)
+                                chargeCount = max(chargeCount, 0.0) // can be negative in weird cases
                                 player.GetOffhandWeapon(1).SetWeaponPrimaryClipCount(int(chargeCount))
                             }
                         }


### PR DESCRIPTION
Should fix the following error, but it happens rarely so I haven't verified it, nor can I replicate it:

```
[06:47:12] [info] [SERVER SCRIPT] SCRIPT ERROR: [SERVER] Count [-1] is negative.
[06:47:12] [info] [SERVER SCRIPT]  -> player.GetOffhandWeapon(1).SetWeaponPrimaryClipCount(int(chargeCount))
[06:47:12] [info] [SERVER SCRIPT]
CALLSTACK
*FUNCTION [HoloRecharge_Threaded()] holoshift_recharge.gnut line [36]

[06:47:12] [info] [SERVER SCRIPT] LOCALS
[chargeCount] -1.2255859375
[@ITERATOR@] 1
[player] ENTITY (player fvnkhead [1] (player "fvnkhead" at <-1467.72 -460.623 657.608>))
[@INDEX@] 0
[players] ARRAY
[rechargeMultiplier] 10
[this] TABLE

DIAGPRINTS

0024:fixme:msvcp:_Locinfo__Locinfo_ctor_cat_cstr (00000000007CE1A0 1 C) semi-stub
0024:fixme:msvcp:_Locinfo__Locinfo_ctor_cat_cstr (00000000007CDEF0 1 C) semi-stub
[06:47:12] [error] Northstar has crashed! a minidump has been written and exception info is available below:
[06:47:12] [error] Cause: Access Violation
Attempted to read from: 0x0000000000000000
[06:47:12] [error] At: engine.dll + 0x247d3a
[06:47:12] [error]     Northstar.dll + 0x52b33 (0x16912b33)
[06:47:12] [error]     ntdll.dll + 0x25753 (0x170025753)
[06:47:12] [error]     ntdll.dll + 0x548c5 (0x1700548c5)
[06:47:12] [error]     ntdll.dll + 0x5245e (0x17005245e)
[06:47:12] [error]     engine.dll + 0x247d3a (0x1d657d3a)
[06:47:12] [error]     engine.dll + 0x417466 (0x1d827466)
[06:47:12] [error]     engine.dll + 0x120c2f (0x1d530c2f)
[06:47:12] [error]     engine.dll + 0x120542 (0x1d530542)
[06:47:12] [error]     engine.dll + 0x16db55 (0x1d57db55)
[06:47:12] [error]     engine.dll + 0x1c88c0 (0x1d5d88c0)
[06:47:12] [error]     Northstar.dll + 0x3d306 (0x168fd306)
[06:47:12] [error]     engine.dll + 0x1c652f (0x1d5d652f)
[06:47:12] [error]     engine.dll + 0x390e2d (0x1d7a0e2d)
[06:47:12] [error]     engine.dll + 0x1c79d9 (0x1d5d79d9)
[06:47:12] [error]     engine.dll + 0x1c793c (0x1d5d793c)
[06:47:12] [error]     launcher.dll + 0x15afd (0x16b45afd)
[06:47:12] [error]     launcher.dll + 0x15afd (0x16b45afd)
[06:47:12] [error]     launcher.dll + 0xd386 (0x16b3d386)
[06:47:12] [error]     NorthstarLauncher.exe + 0x45e0 (0x1400045e0)
[06:47:12] [error]     NorthstarLauncher.exe + 0x7900 (0x140007900)
[06:47:12] [error]     kernel32.dll + 0x2c599 (0x7b62c599)
[06:47:12] [error]     ntdll.dll + 0x59d53 (0x170059d53)
[06:47:12] [error]     NorthstarLauncher.exe + 0xfffffffec0000000 (0x0)
[06:47:12] [error]     NorthstarLauncher.exe + 0x7970 (0x140007970)
[06:47:12] [error]     NorthstarLauncher.exe + 0x67ff0000 (0x67ff0000)
[06:47:12] [error]     NorthstarLauncher.exe + 0xfffffffec0000000 (0x0)
[06:47:12] [error] RAX: 0x0
[06:47:12] [error] RBX: 0x1dbf56d0
[06:47:12] [error] RCX: 0x0
[06:47:12] [error] RDX: 0x0
[06:47:12] [error] RSI: 0x304ebb78
[06:47:12] [error] RDI: 0x304ebb78
[06:47:12] [error] RBP: 0x304ebd88
[06:47:12] [error] RSP: 0x7cf2e0
[06:47:12] [error] R8: 0x304ebb78
[06:47:12] [error] R9: 0x65
[06:47:12] [error] R10: 0x304ebd94
[06:47:12] [error] R11: 0x1da178ec
[06:47:12] [error] R12: 0x0
[06:47:12] [error] R13: 0x0
[06:47:12] [error] R14: 0xffffffff
[06:47:12] [error] R15: 0x1
0024:fixme:dbghelp_dwarf:dwarf2_read_range no entry found
0024:fixme:dbghelp_dwarf:dwarf2_read_range no entry found
0024:fixme:dbghelp:MiniDumpWriteDump NIY MiniDumpScanMemory
nswrap: northstar exited with status 100
nswrap: killing xvfb
nswrap: waiting for children to exit
```