### PR TITLE
Added HoloTracker compatibility

### DIFF
--- a/keyvalues/scripts/weapons/mp_ability_holopilot.txt
+++ b/keyvalues/scripts/weapons/mp_ability_holopilot.txt
@@ -32,5 +32,9 @@ WeaponData
 			"ammo_stockpile_max"							"300"
 			"regen_ammo_refill_rate"						"*1.5"
 		}
+		mode_holoshift
+		{
+			"hud_icon"							"rui/menu/boosts/boost_icon_holopilot"
+		}
 	}
 }

--- a/mod.json
+++ b/mod.json
@@ -1,7 +1,7 @@
 {
   "Name": "Legonzaur.HoloShift",
-  "Description": "Swap positions with your beloved decoy",
-  "Version": "1.0.8",
+  "Description": "Swap positions with your beloved decoy. Compatible with HoloTracker.",
+  "Version": "1.0.9",
   "LoadPriority": 2,
   "Scripts": [
     {
@@ -9,7 +9,14 @@
       "RunOn": "MP",
       "ServerCallback": {
         "After": "HoloShift_Init"
-      }
-    }
+      },
+    },
+	{
+	"Path": "HolopilotIconChange.nut",
+		"RunOn": "MP",
+		"ServerCallback": {
+			"After": "HolopilotIconChangeInit"
+		},
+	}
   ]
 }

--- a/mod/scripts/vscripts/HolopilotIconChange.nut
+++ b/mod/scripts/vscripts/HolopilotIconChange.nut
@@ -1,0 +1,26 @@
+untyped
+global function HolopilotIconChangeInit
+
+
+void function HolopilotIconChangeInit()
+{
+	#if SERVER
+		AddCallback_OnPlayerRespawned( HolopilotIconChange )
+		//AddCallback_PlayerClassChanged( HolopilotIconChange )
+		//AddCallback_OnPlayerLifeStateChanged( HolopilotIconChange )
+	#endif
+}
+
+#if SERVER
+
+void function HolopilotIconChange(entity player){
+//void function HolopilotIconChange(entity player, int oldState, int newState){
+	Assert( IsAlive( player ) )
+	if(player.GetOffhandWeapons().len() > 1 && player.GetOffhandWeapons()[1].GetWeaponClassName() == "mp_ability_holopilot"){
+		array <string> offhandMods = player.GetOffhandWeapons()[1].GetMods()
+		offhandMods.append("mode_holoshift")
+		player.GetOffhandWeapons()[1].SetMods(offhandMods)
+	}
+		
+}
+#endif

--- a/mod/scripts/vscripts/weapons/mp_ability_holopilot.nut
+++ b/mod/scripts/vscripts/weapons/mp_ability_holopilot.nut
@@ -46,6 +46,10 @@ void function CleanupExistingDecoy( entity decoy )
 {
 	if ( IsValid( decoy ) ) //This cleanup function is called from multiple places, so check that decoy is still valid before we try to clean it up again
 	{
+		//COMMUNICATION WITH HOLOTRACKER
+		int eHandle = decoy.GetEncodedEHandle()
+		ServerToClientStringCommand( decoy.GetBossPlayer(), "StopDecoyTracking " + eHandle.tostring())
+		//END OF COMMUNICATION
 		decoy.Decoy_Dissolve()
 		CleanupFXAndSoundsForDecoy( decoy )
 	}
@@ -158,6 +162,11 @@ var function OnWeaponPrimaryAttack_holopilot( entity weapon, WeaponPrimaryAttack
 	}else{
 		entity decoy = CreateHoloPilotDecoys( weaponOwner, 1 )
 		playerDecoyList[ weaponOwner ] <- decoy
+		
+		//COMMUNICATION WITH HOLOTRACKER
+		int eHandle = decoy.GetEncodedEHandle()
+		ServerToClientStringCommand( weaponOwner, "ActivateDecoyTracking " + eHandle.tostring())
+		//END OF COMMUNICATION
 	}
 #else
 	Rumble_Play( "rumble_holopilot_activate", {} )


### PR DESCRIPTION
Adds compatibility with the optional client-side mod HoloTracker. Apart from sending the mod an encoded handle of the decoy entity, it adds a weapon mod to holopilot ability on player spawn, which alters it's icon for anyone with HoloTracker.